### PR TITLE
ci: Add CI status and test coverage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@
   <a href="https://pypi.org/project/penpot-mcp/">
     <img src="https://img.shields.io/pypi/v/penpot-mcp" alt="PyPI version">
   </a>
-  <a href="https://github.com/montevive/penpot-mcp/actions">
-    <img src="https://img.shields.io/github/workflow/status/montevive/penpot-mcp/CI" alt="Build Status">
+  <a href="https://github.com/montevive/penpot-mcp/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/actions/workflow/status/montevive/penpot-mcp/ci.yml?branch=main&label=tests" alt="CI Status">
+  </a>
+  <a href="https://codecov.io/gh/montevive/penpot-mcp">
+    <img src="https://codecov.io/gh/montevive/penpot-mcp/branch/main/graph/badge.svg" alt="Coverage">
   </a>
 </p>
 


### PR DESCRIPTION
## Summary

This PR adds modern CI status and code coverage badges to the README to demonstrate that automated testing is configured to run on all pull requests.

## Changes

- Updated CI badge to use modern GitHub Actions workflow badge format
- Added Codecov coverage badge to track test coverage
- Links badges to the CI workflow runs and coverage reports

## Testing

This PR itself demonstrates that CI is working on pull requests. The CI workflow includes:

- ✅ Tests across Python 3.10, 3.11, 3.12, 3.13
- ✅ Code coverage reporting via Codecov
- ✅ Linting checks
- ✅ Security scanning with Bandit
- ✅ Build verification
- ✅ Docker build tests

The CI workflow is configured to run automatically on:
- All pull requests targeting `main` or `develop` branches
- All pushes to `main` or `develop` branches

You can view the CI configuration at `.github/workflows/ci.yml`