### PR TITLE
test: improve test clarity and remove placeholder tests

### DIFF
--- a/tests/test_mcp_comments.py
+++ b/tests/test_mcp_comments.py
@@ -41,10 +41,11 @@ def mock_server():
     return server
 
 
-# ========== MCP TOOL TESTS ==========
+# ========== API MOCK TESTS ==========
+# These tests verify the API mock behavior works correctly
 
-def test_add_design_comment_tool(mock_server):
-    """Test add_design_comment MCP tool."""
+def test_create_comment_thread_api_mock(mock_server):
+    """Test create_comment_thread API mock returns expected data."""
     result = mock_server.api.create_comment_thread(
         file_id='file-123',
         page_id='page-456',
@@ -58,8 +59,8 @@ def test_add_design_comment_tool(mock_server):
     assert result['content'] == 'Test comment'
 
 
-def test_reply_to_comment_tool(mock_server):
-    """Test reply_to_comment MCP tool."""
+def test_add_comment_api_mock(mock_server):
+    """Test add_comment API mock returns expected data."""
     result = mock_server.api.add_comment(
         thread_id='thread-456',
         content='I agree with this feedback'
@@ -70,8 +71,8 @@ def test_reply_to_comment_tool(mock_server):
     assert result['content'] == 'Test reply'
 
 
-def test_get_file_comments_tool(mock_server):
-    """Test get_file_comments MCP tool."""
+def test_get_comment_threads_api_mock(mock_server):
+    """Test get_comment_threads API mock returns expected data."""
     result = mock_server.api.get_comment_threads(
         file_id='file-123',
         page_id='page-456'
@@ -82,8 +83,8 @@ def test_get_file_comments_tool(mock_server):
     assert result[1]['id'] == 'thread-2'
 
 
-def test_resolve_comment_thread_tool(mock_server):
-    """Test resolve_comment_thread MCP tool."""
+def test_update_comment_thread_status_api_mock(mock_server):
+    """Test update_comment_thread_status API mock returns expected data."""
     result = mock_server.api.update_comment_thread_status(
         thread_id='thread-123',
         is_resolved=True
@@ -132,34 +133,3 @@ class TestCommentWorkflow:
 
         # Verify different positions
         assert threads[0]['position'] != threads[1]['position']
-
-
-class TestCommentErrorHandling:
-    """Test error handling for comment tools."""
-
-    def test_create_comment_with_error(self, mock_server):
-        """Test that create_comment_thread handles errors."""
-        mock_server.api.create_comment_thread = MagicMock(
-            side_effect=Exception("API Error")
-        )
-
-        # Tool should handle the error gracefully
-        # (actual invocation would require calling through FastMCP)
-
-    def test_reply_with_invalid_thread(self, mock_server):
-        """Test that add_comment handles invalid thread ID."""
-        mock_server.api.add_comment = MagicMock(
-            side_effect=Exception("Thread not found")
-        )
-
-        # Tool should handle the error
-        # (actual invocation would require calling through FastMCP)
-
-    def test_resolve_nonexistent_thread(self, mock_server):
-        """Test that resolve handles nonexistent thread."""
-        mock_server.api.update_comment_thread_status = MagicMock(
-            side_effect=Exception("Thread not found")
-        )
-
-        # Tool should handle the error
-        # (actual invocation would require calling through FastMCP)

--- a/tests/test_mcp_libraries.py
+++ b/tests/test_mcp_libraries.py
@@ -48,10 +48,11 @@ def mock_server():
     return server
 
 
-# ========== MCP TOOL TESTS ==========
+# ========== API MOCK TESTS ==========
+# These tests verify the API mock behavior works correctly
 
-def test_link_library_tool(mock_server):
-    """Test link_library MCP tool."""
+def test_link_file_to_library_api_mock(mock_server):
+    """Test link_file_to_library API mock returns expected data."""
     result = mock_server.api.link_file_to_library(
         file_id='file-123',
         library_id='lib-456'
@@ -61,8 +62,8 @@ def test_link_library_tool(mock_server):
     assert 'lib-456' in result['linkedLibraries']
 
 
-def test_list_library_components_tool(mock_server):
-    """Test list_library_components MCP tool."""
+def test_get_library_components_api_mock(mock_server):
+    """Test get_library_components API mock returns expected data."""
     result = mock_server.api.get_library_components(
         library_id='lib-456'
     )
@@ -72,8 +73,8 @@ def test_list_library_components_tool(mock_server):
     assert result[2]['name'] == 'Modal'
 
 
-def test_import_component_tool(mock_server):
-    """Test import_component MCP tool."""
+def test_instantiate_component_api_mock(mock_server):
+    """Test instantiate_component API mock returns expected data."""
     result = mock_server.api.instantiate_component(
         file_id='file-123',
         page_id='page-456',
@@ -87,8 +88,8 @@ def test_import_component_tool(mock_server):
     assert result['revn'] == 6
 
 
-def test_import_component_tool_with_frame(mock_server):
-    """Test import_component MCP tool with frame_id."""
+def test_instantiate_component_with_frame_api_mock(mock_server):
+    """Test instantiate_component API mock with frame_id parameter."""
     result = mock_server.api.instantiate_component(
         file_id='file-123',
         page_id='page-456',
@@ -112,8 +113,8 @@ def test_import_component_tool_with_frame(mock_server):
     )
 
 
-def test_sync_library_tool(mock_server):
-    """Test sync_library MCP tool."""
+def test_sync_file_library_api_mock(mock_server):
+    """Test sync_file_library API mock returns expected data."""
     result = mock_server.api.sync_file_library(
         file_id='file-123',
         library_id='lib-456'
@@ -124,8 +125,8 @@ def test_sync_library_tool(mock_server):
     assert result['library-id'] == 'lib-456'
 
 
-def test_publish_as_library_tool(mock_server):
-    """Test publish_as_library MCP tool."""
+def test_publish_library_api_mock(mock_server):
+    """Test publish_library API mock returns expected data."""
     result = mock_server.api.publish_library(
         file_id='file-123',
         publish=True
@@ -135,14 +136,14 @@ def test_publish_as_library_tool(mock_server):
     assert result['is-shared'] is True
 
 
-def test_unpublish_library_tool(mock_server):
-    """Test unpublish_library MCP tool."""
+def test_unpublish_library_api_mock(mock_server):
+    """Test publish_library API mock with publish=False."""
     # Mock the unpublish response
     mock_server.api.publish_library = MagicMock(return_value={
         'id': 'file-123',
         'is-shared': False
     })
-    
+
     result = mock_server.api.publish_library(
         file_id='file-123',
         publish=False
@@ -152,8 +153,8 @@ def test_unpublish_library_tool(mock_server):
     assert result['is-shared'] is False
 
 
-def test_get_file_libraries_tool(mock_server):
-    """Test get_file_libraries MCP tool."""
+def test_get_file_libraries_api_mock(mock_server):
+    """Test get_file_libraries API mock returns expected data."""
     result = mock_server.api.get_file_libraries(
         file_id='file-123'
     )


### PR DESCRIPTION
## Summary

Addresses test quality issues identified in code reviews for PR #26 and PR #28 by improving test naming clarity and removing non-functional placeholder tests.

## Changes

### 1. Renamed "MCP TOOL TESTS" to "API MOCK TESTS"

**Files:** `tests/test_mcp_comments.py`, `tests/test_mcp_libraries.py`

The tests previously labeled as "MCP tool tests" were actually verifying API mock behavior, not the MCP tools themselves. Renamed sections and updated function names/docstrings to accurately reflect what they test:

**Before:**
```python
# ========== MCP TOOL TESTS ==========

def test_add_design_comment_tool(mock_server):
    """Test add_design_comment MCP tool."""
    result = mock_server.api.create_comment_thread(...)  # Calls API, not tool
```

**After:**
```python
# ========== API MOCK TESTS ==========
# These tests verify the API mock behavior works correctly

def test_create_comment_thread_api_mock(mock_server):
    """Test create_comment_thread API mock returns expected data."""
    result = mock_server.api.create_comment_thread(...)
```

### 2. Removed Placeholder Error Handling Tests

**File:** `tests/test_mcp_comments.py`

Removed 3 placeholder tests that contained no assertions and were misleading:

- `test_create_comment_with_error`
- `test_reply_with_invalid_thread`
- `test_resolve_nonexistent_thread`

These tests only set up mocks to throw exceptions but didn't actually verify any error handling behavior.

### 3. Updated Test Function Names

Renamed all test functions to clarify they test API mocks:

**test_mcp_comments.py:**
- `test_add_design_comment_tool` → `test_create_comment_thread_api_mock`
- `test_reply_to_comment_tool` → `test_add_comment_api_mock`
- `test_get_file_comments_tool` → `test_get_comment_threads_api_mock`
- `test_resolve_comment_thread_tool` → `test_update_comment_thread_status_api_mock`

**test_mcp_libraries.py:**
- `test_link_library_tool` → `test_link_file_to_library_api_mock`
- `test_list_library_components_tool` → `test_get_library_components_api_mock`
- `test_import_component_tool` → `test_instantiate_component_api_mock`
- `test_import_component_tool_with_frame` → `test_instantiate_component_with_frame_api_mock`
- `test_sync_library_tool` → `test_sync_file_library_api_mock`
- `test_publish_as_library_tool` → `test_publish_library_api_mock`
- `test_unpublish_library_tool` → `test_unpublish_library_api_mock`
- `test_get_file_libraries_tool` → `test_get_file_libraries_api_mock`

## Testing

All 318 tests still pass:

```bash
pytest tests/test_mcp_comments.py tests/test_mcp_libraries.py -v
# 24 passed in 1.82s

pytest
# 318 passed in 10.45s
```

## Impact

- **Improved clarity**: Test names now accurately describe what they verify
- **Removed confusion**: No more misleading "MCP tool" labels on API-level tests
- **Cleaner test suite**: Removed 3 non-functional placeholder tests
- **No breaking changes**: All existing tests still pass

## Related

- Addresses review feedback from PR #26
- Addresses review feedback from PR #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)